### PR TITLE
add support for gulpfiles written in CoffeeScript

### DIFF
--- a/gulp-autocompletion.zsh
+++ b/gulp-autocompletion.zsh
@@ -20,7 +20,7 @@
 # `gulpfile.coffee` in the current directory.
 #
 function $$gulp_completion() {
-    compls=$(grep -Eo "gulp.task\(? *('(([a-zA-Z0-9]|-)*)',)" gulpfile.{js,coffee} 2>/dev/null | grep -Eo "'(([a-zA-Z0-9]|-)*)'" | sed s/"'"//g | sort)
+    compls=$(grep -Eo "gulp.task\(? *([\"'](([a-zA-Z0-9]|-)*)[\"'],)" gulpfile.{js,coffee} 2>/dev/null | grep -Eo "[\"'](([a-zA-Z0-9]|-)*)[\"']" | sed s/"'"//g | sort)
 
     completions=(${=compls})
     compadd -- $completions

--- a/gulp-autocompletion.zsh
+++ b/gulp-autocompletion.zsh
@@ -16,11 +16,11 @@
 #
 
 #
-# Grabs all available tasks from the `gulpfile.js`
-# in the current directory.
+# Grabs all available tasks from any `gulpfile.js` or
+# `gulpfile.coffee` in the current directory.
 #
 function $$gulp_completion() {
-    compls=$(grep -Eo "gulp.task\(('(([a-zA-Z0-9]|-)*)',)" gulpfile.js 2>/dev/null | grep -Eo "'(([a-zA-Z0-9]|-)*)'" | sed s/"'"//g | sort)
+    compls=$(grep -Eo "gulp.task\(? *('(([a-zA-Z0-9]|-)*)',)" gulpfile.{js,coffee} 2>/dev/null | grep -Eo "'(([a-zA-Z0-9]|-)*)'" | sed s/"'"//g | sort)
 
     completions=(${=compls})
     compadd -- $completions

--- a/gulp-autocompletion.zsh
+++ b/gulp-autocompletion.zsh
@@ -20,7 +20,7 @@
 # `gulpfile.coffee` in the current directory.
 #
 function $$gulp_completion() {
-    compls=$(grep -Eo "gulp.task\(? *([\"'](([a-zA-Z0-9]|-)*)[\"'],)" gulpfile.{js,coffee} 2>/dev/null | grep -Eo "[\"'](([a-zA-Z0-9]|-)*)[\"']" | sed s/"'"//g | sort)
+    compls=$(grep -Eho "gulp\.task[^,]*" gulpfile.* 2>/dev/null | sed s/\"/\'/g | cut -d "'" -f 2 | sort)
 
     completions=(${=compls})
     compadd -- $completions


### PR DESCRIPTION
We write our gulpfiles using CoffeeScript (and just have a require to them in the normal gulpfile.js). This change supports both the looser CoffeeScript syntax (parentheses are optional) and the filename extension.
